### PR TITLE
Temporarily switch to parcel-bundler-fork to get Elm fixes.

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -22,6 +22,6 @@
     "elm-hot": "^1.0.1",
     "elm-test": "^0.19.0-rev3",
     "node-elm-compiler": "^5.0.1",
-    "parcel-bundler": "^1.11.0"
+    "parcel-bundler-fork": "^1.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-app-gen",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A CLI for generating Elm projects that build with Parcel",
   "keywords": [
     "elm",


### PR DESCRIPTION
This updates projects to use a fork of parcel that includes a fix
for https://github.com/parcel-bundler/parcel/issues/2147  once
that fix is relased in the official parcel package, we should
switch back, and open a PR against parcel-bundler-fork to notify
users to update their dependencies.

@kalutheo - I'm not super excited about this change, but hopefully parcel will release that fix soon. I don't want to publicize this tool too much until that's ready, but this will make the experience nicer while using it in the meantime.