### PR TITLE
Add missing annotation for main function in document template

### DIFF
--- a/generators/app/templates/elm/document/src/Main.elm
+++ b/generators/app/templates/elm/document/src/Main.elm
@@ -12,6 +12,7 @@ import Json.Decode exposing (Decoder, field, string)
 -- MAIN
 
 
+main : Program () Model Msg
 main =
     Browser.document
         { init = init


### PR DESCRIPTION
Just a super minor addition. It'll quell a elm-analyse complaint.

Thanks for making elm-app-gen.