### PR TITLE
Add routing support for elm application scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 generators/app/package-lock.json
 generators/app/templates/elm-stuff/
+
+.idea/

--- a/generators/app/templates/elm/application/src/Main.elm
+++ b/generators/app/templates/elm/application/src/Main.elm
@@ -4,6 +4,7 @@ import Browser
 import Browser.Navigation as Nav
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Routing
 import Url
 
 
@@ -53,7 +54,7 @@ update msg model =
         LinkClicked urlRequest ->
             case urlRequest of
                 Browser.Internal url ->
-                    ( model, Nav.pushUrl model.key (Url.toString url) )
+                    ( model, Routing.routeTo model.key url )
 
                 Browser.External href ->
                     ( model, Nav.load href )
@@ -84,16 +85,16 @@ view model =
         [ text "The current URL is: "
         , b [] [ text (Url.toString model.url) ]
         , ul []
-            [ viewLink "/home"
-            , viewLink "/profile"
-            , viewLink "/reviews/the-century-of-the-self"
-            , viewLink "/reviews/public-opinion"
-            , viewLink "/reviews/shah-of-shahs"
+            [ viewLink "/home" Routing.Home
+            , viewLink "/profile" Routing.Profile
+            , viewLink "/reviews/the-century-of-the-self" (Routing.Review "the-century-of-the-self")
+            , viewLink "/reviews/public-opinion" (Routing.Review "public-opinion")
+            , viewLink "/reviews/shah-of-shahs" (Routing.Review "shah-of-shahs")
             ]
         ]
     }
 
 
-viewLink : String -> Html msg
-viewLink path =
-    li [] [ a [ href path ] [ text path ] ]
+viewLink : String -> Routing.Route -> Html msg
+viewLink text route =
+    li [] [ Routing.routeLink text ( route, Nothing ) ]

--- a/generators/app/templates/elm/application/src/Routing.elm
+++ b/generators/app/templates/elm/application/src/Routing.elm
@@ -1,0 +1,92 @@
+module Routing exposing (Route(..), routeLink, routeTo)
+
+import Browser.Navigation as Navigation
+import Html exposing (Html, a, text)
+import Html.Attributes exposing (href)
+import Html.Events exposing (onClick)
+import Url exposing (Url)
+import Url.Builder as Builder
+import Url.Parser exposing ((</>), Parser, int, map, oneOf, parse, s, string, top)
+
+
+type Route
+    = Home
+    | NotFound
+    | User Int
+    | Profile
+    | Review String
+
+
+routePath : Route -> String
+routePath route =
+    case route of
+        User page ->
+            Builder.absolute
+                [ "user", String.fromInt page ]
+                []
+
+        Profile ->
+            Builder.absolute
+                [ "profile" ]
+                []
+
+        Review review ->
+            Builder.absolute
+                [ "review", review ]
+                []
+
+        Home ->
+            Builder.absolute [ "home" ] []
+
+        NotFound ->
+            Builder.absolute [ "not-found" ] []
+
+
+pushRouteUrl : Route -> Navigation.Key -> Cmd msg
+pushRouteUrl route key =
+    Navigation.pushUrl key (routePath route)
+
+
+parseRoute : Parser (Route -> a) a
+parseRoute =
+    oneOf
+        [ map Home
+            (s "home")
+        , map User
+            (s "user" </> int)
+        , map Profile
+            (s "profile")
+        , map Review
+            (s "review" </> string)
+        ]
+
+
+routeFromUrl : Url -> Route
+routeFromUrl url =
+    case parse parseRoute url of
+        Just route ->
+            route
+
+        Nothing ->
+            NotFound
+
+
+routeLink : String -> ( Route, Maybe msg ) -> Html msg
+routeLink text_ ( route, handler ) =
+    case handler of
+        Nothing ->
+            a [ href (routePath route) ]
+                [ text text_ ]
+
+        Just clickMsg ->
+            a [ href (routePath route), onClick clickMsg ]
+                [ text text_ ]
+
+
+routeTo : Navigation.Key -> Url -> Cmd msg
+routeTo key url =
+    let
+        route =
+            routeFromUrl url
+    in
+    pushRouteUrl route key

--- a/package-lock.json
+++ b/package-lock.json
@@ -2440,6 +2440,17 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "elm-debug-transformer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elm-debug-transformer/-/elm-debug-transformer-1.0.1.tgz",
+      "integrity": "sha512-eN8C47Hrdk2b70iIzRP8V4Mrh5spmh5m7GTo/Ls1/hszPNDOW/7gLoPdtVJohKeP3/wc2lS8482cF7RjWuesfA=="
+    },
+    "elm-hot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/elm-hot/-/elm-hot-1.1.2.tgz",
+      "integrity": "sha512-rz0xMz71NTkDMPMepelg67kvs/5CnrE2dDzJJC0TpSgyEU/mjdUL8x1qewJGzTGXwHyg3Trt1CHPiTR9nImmJA==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2792,6 +2803,16 @@
         }
       }
     },
+    "find-elm-dependencies": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/find-elm-dependencies/-/find-elm-dependencies-2.0.2.tgz",
+      "integrity": "sha512-nM5UCbccD1G8CGK2GsM7ykG3ksOAl9E+34jiDfl07CAl2OPnLpBVWY2hlxEmIkSBfdJjSopEowWHrO0cI8RhxQ==",
+      "dev": true,
+      "requires": {
+        "firstline": "1.2.0",
+        "lodash": "4.17.15"
+      }
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -2807,6 +2828,12 @@
       "requires": {
         "readable-stream": "^2.0.2"
       }
+    },
+    "firstline": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/firstline/-/firstline-1.2.0.tgz",
+      "integrity": "sha1-yfSIbn9/vwr8EtcZQdzgaxkq6gU=",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -4684,6 +4711,18 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.3.tgz",
       "integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg=="
+    },
+    "node-elm-compiler": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/node-elm-compiler/-/node-elm-compiler-5.0.4.tgz",
+      "integrity": "sha512-VQsT8QSierYGkHzRed+b4MnccQVF1+qPHunE8jBoU7jD6YpuRqCDPzEoC2zfyEJS80qVnlMZrqobLnyjzX9lJg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "6.0.5",
+        "find-elm-dependencies": "2.0.2",
+        "lodash": "4.17.15",
+        "temp": "^0.9.0"
+      }
     },
     "node-forge": {
       "version": "0.7.6",
@@ -6867,6 +6906,15 @@
       "dev": true,
       "requires": {
         "acorn-node": "^1.2.0"
+      }
+    },
+    "temp": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz",
+      "integrity": "sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==",
+      "dev": true,
+      "requires": {
+        "rimraf": "~2.6.2"
       }
     },
     "terser": {

--- a/package.json
+++ b/package.json
@@ -28,11 +28,14 @@
   "dependencies": {
     "commander": "^3.0.0",
     "cross-spawn": "^6.0.5",
+    "elm-debug-transformer": "^1.0.1",
     "parcel-bundler": "^1.12.3",
     "yeoman-environment": "^2.4.0",
     "yeoman-generator": "^3.1.1"
   },
   "devDependencies": {
-    "ejs-lint": "^0.3.0"
+    "ejs-lint": "^0.3.0",
+    "elm-hot": "^1.1.2",
+    "node-elm-compiler": "^5.0.4"
   }
 }


### PR DESCRIPTION
A couple things coming with this:

 - Helper for automatic link generation based on route
 - Route detection based on provided parsers
 - Optional `onClick` handler passing in case you need to trigger a side effect

The idea is to keep anything routing related for an application inside of the Routing module and reach in to grab your routes and a couple helpers.

This opens up a chance to explore a "Pages" concept to encapsulate related behaviors (views, side effects, decoders, etc)