### PR TITLE
elm upgrade to 0.19.1

### DIFF
--- a/generators/app/templates/elm/application/_elm.json
+++ b/generators/app/templates/elm/application/_elm.json
@@ -2,10 +2,10 @@
   "name": "<%= name %>",
   "type": "application",
   "source-directories": ["src"],
-  "elm-version": "0.19.0",
+  "elm-version": "0.19.1",
   "dependencies": {
     "direct": {
-      "elm/browser": "1.0.1",
+      "elm/browser": "1.0.2",
       "elm/core": "1.0.2",
       "elm/html": "1.0.0",
       "elm/url": "1.0.0"

--- a/generators/app/templates/elm/document/_elm.json
+++ b/generators/app/templates/elm/document/_elm.json
@@ -2,10 +2,10 @@
   "name": "<%= name %>",
   "type": "application",
   "source-directories": ["src"],
-  "elm-version": "0.19.0",
+  "elm-version": "0.19.1",
   "dependencies": {
     "direct": {
-      "elm/browser": "1.0.1",
+      "elm/browser": "1.0.2",
       "elm/core": "1.0.2",
       "elm/html": "1.0.0",
       "elm/http": "2.0.0",

--- a/generators/app/templates/elm/element/_elm.json
+++ b/generators/app/templates/elm/element/_elm.json
@@ -4,10 +4,10 @@
     "source-directories": [
         "src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.1",
+            "elm/browser": "1.0.2",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",

--- a/generators/app/templates/elm/sandbox/_elm.json
+++ b/generators/app/templates/elm/sandbox/_elm.json
@@ -2,10 +2,10 @@
   "name": "<%= name %>",
   "type": "application",
   "source-directories": ["src"],
-  "elm-version": "0.19.0",
+  "elm-version": "0.19.1",
   "dependencies": {
     "direct": {
-      "elm/browser": "1.0.1",
+      "elm/browser": "1.0.2",
       "elm/core": "1.0.2",
       "elm/html": "1.0.0",
       "elm/url": "1.0.0"

--- a/generators/app/templates/parcel/package.json
+++ b/generators/app/templates/parcel/package.json
@@ -18,11 +18,11 @@
   <% } %>
   "dependencies": {},
   "devDependencies": {
-    "elm": "^0.19.0-no-deps",
-    "elm-debug-transformer": "0.0.7",
-    "elm-hot": "^1.0.1",
-    "elm-test": "^0.19.0-rev6",
-    "node-elm-compiler": "^5.0.3",
+    "elm": "^0.19.1-3",
+    "elm-debug-transformer": "^1.0.0",
+    "elm-hot": "^1.1.0",
+    "elm-test": "^0.19.1",
+    "node-elm-compiler": "^5.0.0",
     "parcel-bundler": "^1.12.0"
   }
 }


### PR DESCRIPTION
Upgrading templates to use `elm 0.19.1` and `elm/browser 1.0.2` with the latest elm debugger.